### PR TITLE
Change query-capture to native-query-capture

### DIFF
--- a/assets/images/coverage.svg
+++ b/assets/images/coverage.svg
@@ -9,13 +9,13 @@
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h63v20H0z"/>
-        <path fill="#4c1" d="M63 0h36v20H63z"/>
+        <path fill="#97CA00" d="M63 0h36v20H63z"/>
         <path fill="url(#b)" d="M0 0h99v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">98%</text>
-        <text x="80" y="14">98%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">94%</text>
+        <text x="80" y="14">94%</text>
     </g>
 </svg>

--- a/django_query_capture/__init__.py
+++ b/django_query_capture/__init__.py
@@ -1,7 +1,7 @@
-from .capture import query_capture
+from .capture import native_query_capture
 from .presenter import *
 
 __all__ = [
-    "query_capture",
+    "native_query_capture",
     "RawLinePresenter",
 ]

--- a/django_query_capture/capture.py
+++ b/django_query_capture/capture.py
@@ -22,7 +22,7 @@ class CapturedQuery(typing.TypedDict):
     context: CapturedQueryContext
 
 
-class query_capture(ContextDecorator):
+class native_query_capture(ContextDecorator):
     def __init__(self):
         self._exit_stack = ExitStack().__enter__()
         self.captured_queries: typing.List[CapturedQuery] = []

--- a/tests/test_presenter.py
+++ b/tests/test_presenter.py
@@ -1,12 +1,12 @@
 from django.test import TestCase
 from news.models import Reporter
 
-from django_query_capture import RawLinePresenter, query_capture
+from django_query_capture import RawLinePresenter, native_query_capture
 from django_query_capture.classify import CapturedQueryClassifier
 
 
 class RawLinePresenterTests(TestCase):
     def test_print(self):
-        with query_capture() as q:
+        with native_query_capture() as q:
             [Reporter.objects.create(full_name="target-i") for i in range(11)]
             RawLinePresenter(CapturedQueryClassifier(q.captured_queries)()).print()

--- a/tests/test_query_capture.py
+++ b/tests/test_query_capture.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 from django.utils import timezone
 from news.models import Article, Reporter
 
-from django_query_capture import query_capture
+from django_query_capture import native_query_capture
 
 
 class QueryCaptureTests(TestCase):
@@ -12,7 +12,7 @@ class QueryCaptureTests(TestCase):
         Reporter.objects.create(full_name="target")
 
     def test_capture_query_in_context_manager(self):
-        with query_capture() as q:
+        with native_query_capture() as q:
             r = Reporter.objects.create(full_name="target-1")
             Article.objects.create(
                 pub_date=timezone.now().date(),
@@ -25,5 +25,5 @@ class QueryCaptureTests(TestCase):
     # TODO: Change to a test to see if the query is captured when using Decorator.
     def test_capture_query_in_decorator(self):
         func = Mock()
-        query_capture()(func)()
+        native_query_capture()(func)()
         self.assertTrue(func.called)


### PR DESCRIPTION
## Description

The existing query_capture logic is native logic, so we changed its name to native_query_capture.

## Type of Change

- [ x ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
