### PR TITLE
Add assert_inefficient_query to test_utils module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,7 +229,7 @@ ipython_config.py
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ Some reasons you might want to use django-query-capture:
 - Fully Documented
 - It supports Type hint everywhere.
 
+## Installation
+
+```bash
+pip install -U django-query-capture
+```
+
+or install with `Poetry`
+
+```bash
+poetry add django-query-capture
+```
+
 ## Simple Usage
 
 - Just add it to Middleware without any other settings, and it will be output whenever a query occurs.
@@ -69,7 +81,6 @@ When used as Context, you can check the query in real time.
 
 ```python
 from django_query_capture import query_capture
-
 from tests.news.models import Reporter
 
 @query_capture()
@@ -88,9 +99,7 @@ Test code can capture inefficient queries through the `AssertInefficientQuery` U
 
 ```python
 from django.test import TestCase
-
 from django_query_capture.test_utils import AssertInefficientQuery
-
 
 class AssertInefficientQueryTests(TestCase):
     def test_assert_inefficient_query(self):
@@ -98,16 +107,20 @@ class AssertInefficientQueryTests(TestCase):
             self.client.get('/api/reporter')  # desire threshold count 19 but, /api/reporter duplicate query: 20, so raise error
 ```
 
-## Installation
+You can also use a `assert_inefficient_query` decorator to make the test fail when a duplicate query occurs
 
-```bash
-pip install -U django-query-capture
-```
+```python
+from django.test import TestCase
+from news.models import Reporter
+from django_query_capture.test_utils import assert_inefficient_query
 
-or install with `Poetry`
-
-```bash
-poetry add django-query-capture
+class AssertInefficientQueryTests(ConsoleOutputTestCaseMixin, TestCase):
+    @assert_inefficient_query(200)
+    def test_assert_inefficient_query_with_decorator(self):
+        [list(Reporter.objects.all()) for i in range(200)]
+        [Reporter.objects.create(full_name=f"reporter-{i}") for i in range(200)]
+        
+# If change the number(200) in @assert_inefficient_query to 199, the test fails.
 ```
 
 ## Full Documentation

--- a/django_query_capture/decorators.py
+++ b/django_query_capture/decorators.py
@@ -3,7 +3,6 @@ The highest level of module.<br>
 It is a module responsible for both query capture, classification, and output.
 """
 import typing
-
 from contextlib import ContextDecorator, ExitStack
 
 from django.utils.module_loading import import_string

--- a/tests/test_inefficient_query.py
+++ b/tests/test_inefficient_query.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from news.models import Reporter
 from test_presenter.utils import ConsoleOutputTestCaseMixin
 
-from django_query_capture.test_utils import AssertInefficientQuery
+from django_query_capture.test_utils import AssertInefficientQuery, assert_inefficient_query
 
 
 class AssertInefficientQueryTests(ConsoleOutputTestCaseMixin, TestCase):
@@ -11,3 +11,8 @@ class AssertInefficientQueryTests(ConsoleOutputTestCaseMixin, TestCase):
             with AssertInefficientQuery(199, 0):
                 [list(Reporter.objects.all()) for i in range(200)]
                 [Reporter.objects.create(full_name=f"reporter-{i}") for i in range(200)]
+
+    @assert_inefficient_query(200)
+    def test_assert_inefficient_query_with_decorator(self):
+        [list(Reporter.objects.all()) for i in range(200)]
+        [Reporter.objects.create(full_name=f"reporter-{i}") for i in range(200)]


### PR DESCRIPTION
- Add assert_inefficient_query decorator
- Add usage of "assert_inefficient_query" decorator to README

**Problem**
The `assert_inefficient_query` decorator and `with self.assertRaises` statement do not work together.
example:
```python
@assert_inefficient_query(199)
def test_assert_inefficient_query_with_decorator(self):
    with self.assertRaises(AssertionError):
        [list(Reporter.objects.all()) for i in range(200)]
        [Reporter.objects.create(full_name=f"reporter-{i}") for i in range(200)]
```
AssertionError is not caught in the `with self.assertRaises(AssertionError)` block of the above code. This is probably because the decorator's `AssertInefficientQuery` is at a higher level than the `self.assertRaises`.
I'm not sure how to solve this. I can't catch exceptions with `self.assertRaises` at this time. However, when more than the specified number of duplicate/similar queries occur, the function that fails the test works well.